### PR TITLE
feat: Refactor family membership roles and permissions

### DIFF
--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -79,8 +79,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -92,13 +92,11 @@ jobs:
         if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
         env:
           E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
-          E2E_PLANNER_EMAIL: ${{ secrets.E2E_PLANNER_EMAIL }}
           E2E_MEMBER_EMAIL: ${{ secrets.E2E_MEMBER_EMAIL }}
           E2E_VALID_PASSWORD: ${{ secrets.E2E_VALID_PASSWORD }}
         run: |
           missing=()
           [[ -z "$E2E_ADMIN_EMAIL" ]]    && missing+=("E2E_ADMIN_EMAIL")
-          [[ -z "$E2E_PLANNER_EMAIL" ]]  && missing+=("E2E_PLANNER_EMAIL")
           [[ -z "$E2E_MEMBER_EMAIL" ]]   && missing+=("E2E_MEMBER_EMAIL")
           [[ -z "$E2E_VALID_PASSWORD" ]] && missing+=("E2E_VALID_PASSWORD")
           if [[ ${#missing[@]} -gt 0 ]]; then
@@ -126,7 +124,6 @@ jobs:
           E2E_VALID_PASSWORD: ${{ secrets.E2E_VALID_PASSWORD }}
           # Role-specific users for RBAC security tests.
           E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
-          E2E_PLANNER_EMAIL: ${{ secrets.E2E_PLANNER_EMAIL }}
           E2E_MEMBER_EMAIL: ${{ secrets.E2E_MEMBER_EMAIL }}
 
       - name: Fail on skipped security tests

--- a/e2e/tests/security.spec.ts
+++ b/e2e/tests/security.spec.ts
@@ -11,7 +11,6 @@
  * The tests below look for role-specific users through these env vars:
  *
  *   E2E_ADMIN_EMAIL   – email of a user whose Cognito group is ADMIN
- *   E2E_PLANNER_EMAIL – email of a user whose Cognito group is PLANNER
  *   E2E_MEMBER_EMAIL  – email of a user whose Cognito group is MEMBER
  *   E2E_VALID_PASSWORD – shared password for all role-specific users
  *
@@ -564,64 +563,6 @@ test.describe('security.rbac – ADMIN role management (positive)', () => {
     // should be visible.
     const adminHeading = page.getByRole('heading', { name: /admin/i });
     await expect(adminHeading.first()).toBeVisible();
-  });
-});
-
-test.describe('security.rbac – PLANNER create/update permissions (positive)', () => {
-  test('security.rbac.planner-add-vacation-button-visible', async ({
-    page,
-    authPage,
-    vacationsPage,
-  }) => {
-    const planner = getRoleUser('E2E_PLANNER_EMAIL');
-    if (!planner) {
-      test.skip(true, 'E2E_PLANNER_EMAIL not configured – skipping PLANNER role test');
-    }
-
-    await authPage.goto();
-    await authPage.login(planner!.email, planner!.password);
-    await vacationsPage.gotoViaUrl();
-
-    // PLANNER users should see the "Add Vacation" or equivalent create button.
-    const addBtn = page.getByRole('button', { name: /add vacation/i });
-    await expect(addBtn).toBeVisible();
-  });
-
-  test('security.rbac.planner-add-chore-button-visible', async ({
-    page,
-    authPage,
-    choresPage,
-  }) => {
-    const planner = getRoleUser('E2E_PLANNER_EMAIL');
-    if (!planner) {
-      test.skip(true, 'E2E_PLANNER_EMAIL not configured – skipping PLANNER role test');
-    }
-
-    await authPage.goto();
-    await authPage.login(planner!.email, planner!.password);
-    await choresPage.goto();
-
-    // PLANNER users should see the "Add Chore" button.
-    await expect(choresPage.addChoreBtn).toBeVisible();
-  });
-
-  test('security.rbac.planner-add-car-button-visible', async ({
-    page,
-    authPage,
-    carsPage,
-  }) => {
-    const planner = getRoleUser('E2E_PLANNER_EMAIL');
-    if (!planner) {
-      test.skip(true, 'E2E_PLANNER_EMAIL not configured – skipping PLANNER role test');
-    }
-
-    await authPage.goto();
-    await authPage.login(planner!.email, planner!.password);
-    await carsPage.goto();
-
-    // PLANNER users should see the "Add Car" button.
-    const addCarBtn = page.getByRole('button', { name: /add car/i });
-    await expect(addCarBtn).toBeVisible();
   });
 });
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -290,7 +290,7 @@ function DashboardInner({ user, signOut, activeModule, setActiveModule }: Dashbo
                   </span>
                 </button>
               </li>
-              {canAccessModule('reporting', membership.role) && (
+              {canAccessModule('reporting', membership) && (
               <li>
                 <button
                   onClick={() => setActiveModule('reporting')}
@@ -309,7 +309,7 @@ function DashboardInner({ user, signOut, activeModule, setActiveModule }: Dashbo
                 </button>
               </li>
               )}
-              {canAccessModule('admin', membership.role) && (
+              {canAccessModule('admin', membership) && (
                 <li>
                   <button
                     onClick={() => setActiveModule('admin')}
@@ -352,7 +352,7 @@ function DashboardInner({ user, signOut, activeModule, setActiveModule }: Dashbo
 
         {/* Main Content */}
         <main className="flex-1 p-8">
-          {!canAccessModule(activeModule, membership.role) ? (
+          {!canAccessModule(activeModule, membership) ? (
             <div className="flex flex-col items-center justify-center h-64 text-center">
               <svg className="w-16 h-16 text-gray-300 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
@@ -363,13 +363,13 @@ function DashboardInner({ user, signOut, activeModule, setActiveModule }: Dashbo
           ) : (
             <>
           {activeModule === 'vacations' && <VacationsModule user={user} familyId={familyId} />}
-          {activeModule === 'planning' && <PlanningModule user={user} familyId={familyId} role={membership.role} />}
+          {activeModule === 'planning' && <PlanningModule user={user} familyId={familyId} role={membership.role} canPlan={membership.canPlan} />}
           {activeModule === 'property' && <PropertyModule user={user} familyId={familyId} />}
           {activeModule === 'cars' && <CarsModule user={user} familyId={familyId} />}
           {activeModule === 'calendar' && <CalendarModule />}
           {activeModule === 'cookbook' && <CookbookModule user={user} familyId={familyId} />}
-          {activeModule === 'chores' && <ChoresModule user={user} familyId={familyId} role={membership.role} />}
-          {activeModule === 'reporting' && <ReportingModule user={user} familyId={familyId} role={membership.role} />}
+          {activeModule === 'chores' && <ChoresModule user={user} familyId={familyId} role={membership.role} canPlan={membership.canPlan} />}
+          {activeModule === 'reporting' && <ReportingModule user={user} familyId={familyId} role={membership.role} canPlan={membership.canPlan} />}
           {activeModule === 'admin' && <AdminModule user={user} familyId={familyId} membership={membership} />}
           {activeModule === 'profile' && <ProfileModule user={user} membership={membership} onSignOut={signOut} />}
             </>

--- a/src/components/modules/AdminModule.tsx
+++ b/src/components/modules/AdminModule.tsx
@@ -11,10 +11,13 @@ interface AdminModuleProps {
   membership: FamilyMembership;
 }
 
+type StoredMemberRole = FamilyRole | 'PLANNER';
+type InvitePermission = 'MEMBER' | 'PLANNER';
+
 interface FamilyMemberRecord {
   id: string;
   userId: string;
-  role: FamilyRole;
+  role: StoredMemberRole;
   displayName: string | null | undefined;
   familyId: string;
 }
@@ -22,7 +25,7 @@ interface FamilyMemberRecord {
 interface InviteRecord {
   id: string;
   email: string;
-  role: 'MEMBER' | 'PLANNER';
+  role: InvitePermission;
   expiresAt: string;
   status: 'PENDING' | 'ACCEPTED';
   inviteUrl?: string;
@@ -30,15 +33,21 @@ interface InviteRecord {
 
 const ROLE_LABELS: Record<FamilyRole, string> = {
   ADMIN: 'Admin',
-  PLANNER: 'Planner',
   MEMBER: 'Member',
 };
 
 const ROLE_BADGE_CLASSES: Record<FamilyRole, string> = {
   ADMIN: 'bg-purple-100 text-purple-700',
-  PLANNER: 'bg-blue-100 text-blue-700',
   MEMBER: 'bg-gray-100 text-gray-700',
 };
+
+function normalizeRole(role: StoredMemberRole): FamilyRole {
+  return role === 'ADMIN' ? 'ADMIN' : 'MEMBER';
+}
+
+function hasPlanningPermission(role: StoredMemberRole): boolean {
+  return role === 'ADMIN' || role === 'PLANNER';
+}
 
 export default function AdminModule({ user, familyId, membership }: AdminModuleProps) {
   const [members, setMembers] = useState<FamilyMemberRecord[]>([]);
@@ -48,7 +57,7 @@ export default function AdminModule({ user, familyId, membership }: AdminModuleP
 
   // Invite form state
   const [inviteEmail, setInviteEmail] = useState('');
-  const [inviteRole, setInviteRole] = useState<'MEMBER' | 'PLANNER'>('MEMBER');
+  const [inviteCanPlan, setInviteCanPlan] = useState(false);
   const [inviteSubmitting, setInviteSubmitting] = useState(false);
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [generatedInvite, setGeneratedInvite] = useState<InviteRecord | null>(null);
@@ -66,7 +75,7 @@ export default function AdminModule({ user, familyId, membership }: AdminModuleP
         data.map((m: any) => ({
           id: m.id,
           userId: m.userId,
-          role: (m.role ?? 'MEMBER') as FamilyRole,
+          role: (m.role ?? 'MEMBER') as StoredMemberRole,
           displayName: m.displayName,
           familyId: m.familyId,
         }))
@@ -87,9 +96,9 @@ export default function AdminModule({ user, familyId, membership }: AdminModuleP
     }
   }, [familyId, isAdmin, fetchMembers]);
 
-  const adminCount = members.filter((m) => m.role === 'ADMIN').length;
+  const adminCount = members.filter((m) => normalizeRole(m.role) === 'ADMIN').length;
 
-  const updateRole = async (memberId: string, newRole: FamilyRole) => {
+  const updateRole = async (memberId: string, newRole: StoredMemberRole) => {
     setError(null);
 
     const member = members.find((m) => m.id === memberId);
@@ -97,7 +106,7 @@ export default function AdminModule({ user, familyId, membership }: AdminModuleP
 
     // Client-side fast-fail: mirrors the server-side last-admin guard so the
     // UI stays responsive without a round-trip for the most common block.
-    if (member.role === 'ADMIN' && newRole !== 'ADMIN' && adminCount <= 1) {
+    if (normalizeRole(member.role) === 'ADMIN' && newRole !== 'ADMIN' && adminCount <= 1) {
       setError('A family must have at least one administrator.');
       return;
     }
@@ -137,6 +146,7 @@ export default function AdminModule({ user, familyId, membership }: AdminModuleP
 
     setInviteSubmitting(true);
     try {
+      const inviteRole: InvitePermission = inviteCanPlan ? 'PLANNER' : 'MEMBER';
       const result = await client.mutations.createInvite({
         familyId,
         email: trimmedEmail,
@@ -148,12 +158,13 @@ export default function AdminModule({ user, familyId, membership }: AdminModuleP
         setGeneratedInvite({
           id: result.data.id,
           email: result.data.email,
-          role: result.data.role as 'MEMBER' | 'PLANNER',
+          role: result.data.role as InvitePermission,
           expiresAt: result.data.expiresAt,
           status: result.data.status as 'PENDING' | 'ACCEPTED',
           inviteUrl: result.data.inviteUrl,
         });
         setInviteEmail('');
+        setInviteCanPlan(false);
       }
     } catch (err: any) {
       const serverMsg: string | undefined =
@@ -236,19 +247,16 @@ export default function AdminModule({ user, familyId, membership }: AdminModuleP
                 />
               </div>
 
-              <div>
-                <label htmlFor="invite-role" className="block text-sm font-medium text-gray-700 mb-1">
-                  Role
+              <div className="sm:pt-7">
+                <label className="inline-flex items-center gap-2 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    checked={inviteCanPlan}
+                    onChange={(e) => setInviteCanPlan(e.target.checked)}
+                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  Enable planning permissions
                 </label>
-                <select
-                  id="invite-role"
-                  value={inviteRole}
-                  onChange={(e) => setInviteRole(e.target.value as 'MEMBER' | 'PLANNER')}
-                  className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  <option value="MEMBER">Member</option>
-                  <option value="PLANNER">Planner</option>
-                </select>
               </div>
 
               <div className="flex items-end">
@@ -273,7 +281,10 @@ export default function AdminModule({ user, familyId, membership }: AdminModuleP
             <div className="mt-4 p-4 bg-green-50 border border-green-200 rounded-lg">
               <p className="text-sm font-medium text-green-800 mb-2">
                 Invite created for <span className="font-semibold">{generatedInvite.email}</span> as{' '}
-                <span className="font-semibold">{ROLE_LABELS[generatedInvite.role]}</span>
+                <span className="font-semibold">Member</span>
+                {generatedInvite.role === 'PLANNER' && (
+                  <span className="ml-2 text-blue-700">(planning enabled)</span>
+                )}
               </p>
               <div className="flex items-center gap-2">
                 <input
@@ -320,8 +331,10 @@ export default function AdminModule({ user, familyId, membership }: AdminModuleP
         ) : (
           <div className="space-y-3">
             {members.map((member) => {
+              const normalizedRole = normalizeRole(member.role);
+              const canPlan = hasPlanningPermission(member.role);
               const isCurrentUser = member.userId === currentUserId;
-              const isLastAdmin = member.role === 'ADMIN' && adminCount <= 1;
+              const isLastAdmin = normalizedRole === 'ADMIN' && adminCount <= 1;
               const isBusy = saving === member.id;
 
               return (
@@ -343,12 +356,28 @@ export default function AdminModule({ user, familyId, membership }: AdminModuleP
 
                   <div className="flex items-center gap-3">
                     <span
-                      className={`text-xs font-medium px-3 py-1 rounded-full ${ROLE_BADGE_CLASSES[member.role]}`}
+                      className={`text-xs font-medium px-3 py-1 rounded-full ${ROLE_BADGE_CLASSES[normalizedRole]}`}
                     >
-                      {ROLE_LABELS[member.role]}
+                      {ROLE_LABELS[normalizedRole]}
                     </span>
 
-                    {member.role !== 'ADMIN' && (
+                    {normalizedRole === 'MEMBER' && canPlan && (
+                      <span className="text-xs font-medium px-3 py-1 rounded-full bg-blue-100 text-blue-700">
+                        Planning Enabled
+                      </span>
+                    )}
+
+                    {normalizedRole === 'MEMBER' && (
+                      <button
+                        onClick={() => updateRole(member.id, canPlan ? 'MEMBER' : 'PLANNER')}
+                        disabled={isBusy}
+                        className="text-sm bg-blue-600 hover:bg-blue-700 text-white px-3 py-1.5 rounded-lg transition disabled:opacity-50"
+                      >
+                        {isBusy ? 'Saving…' : canPlan ? 'Disable Planning' : 'Enable Planning'}
+                      </button>
+                    )}
+
+                    {normalizedRole !== 'ADMIN' && (
                       <button
                         onClick={() => updateRole(member.id, 'ADMIN')}
                         disabled={isBusy}
@@ -358,7 +387,7 @@ export default function AdminModule({ user, familyId, membership }: AdminModuleP
                       </button>
                     )}
 
-                    {member.role === 'ADMIN' && (
+                    {normalizedRole === 'ADMIN' && (
                       <button
                         onClick={() => updateRole(member.id, 'MEMBER')}
                         disabled={isBusy || isLastAdmin}

--- a/src/components/modules/ChoresModule.tsx
+++ b/src/components/modules/ChoresModule.tsx
@@ -14,6 +14,7 @@ interface ChoresModuleProps {
   user: any;
   familyId: string;
   role: FamilyRole;
+  canPlan: boolean;
 }
 
 const RECURRENCES = ['DAILY', 'WEEKLY', 'MONTHLY', 'ONE_TIME'] as const;
@@ -61,7 +62,7 @@ const RECURRENCE_COLORS: Record<ChoreRecurrence, string> = {
 
 type ActiveTab = 'my-chores' | 'chores' | 'assignments' | 'completions';
 
-export default function ChoresModule({ user, familyId, role }: ChoresModuleProps) {
+export default function ChoresModule({ user, familyId, role, canPlan }: ChoresModuleProps) {
   const [chores, setChores] = useState<any[]>([]);
   const [completions, setCompletions] = useState<any[]>([]);
   const [assignments, setAssignments] = useState<any[]>([]);
@@ -120,13 +121,13 @@ export default function ChoresModule({ user, familyId, role }: ChoresModuleProps
   }, []);
 
   const canManage = useMemo(
-    () => canEditContent(role),
-    [role]
+    () => canEditContent({ role, canPlan }),
+    [role, canPlan]
   );
 
   const canDelete = useMemo(
-    () => canDeleteContent(role),
-    [role]
+    () => canDeleteContent({ role, canPlan }),
+    [role, canPlan]
   );
 
   const fetchChores = async () => {

--- a/src/components/modules/PlanningModule.tsx
+++ b/src/components/modules/PlanningModule.tsx
@@ -33,6 +33,7 @@ interface PlanningModuleProps {
   user: any;
   familyId: string;
   role: FamilyRole;
+  canPlan: boolean;
 }
 
 interface TripForm {
@@ -55,7 +56,7 @@ const emptyForm: TripForm = {
   status: 'PROPOSED',
 };
 
-export default function PlanningModule({ user, familyId, role }: PlanningModuleProps) {
+export default function PlanningModule({ user, familyId, role, canPlan }: PlanningModuleProps) {
   const [tripPlans, setTripPlans] = useState<any[]>([]);
   const [showForm, setShowForm] = useState(false);
   const [editingTrip, setEditingTrip] = useState<any>(null);
@@ -69,7 +70,7 @@ export default function PlanningModule({ user, familyId, role }: PlanningModuleP
     fetchTripPlans();
   }, []);
 
-  const canEdit = canEditContent(role);
+  const canEdit = canEditContent({ role, canPlan });
 
   const fetchTripPlans = async () => {
     try {

--- a/src/components/modules/ReportingModule.tsx
+++ b/src/components/modules/ReportingModule.tsx
@@ -15,9 +15,10 @@ interface ReportingModuleProps {
   user: any;
   familyId: string;
   role: FamilyRole;
+  canPlan: boolean;
 }
 
-export default function ReportingModule({ user, familyId, role }: ReportingModuleProps) {
+export default function ReportingModule({ user, familyId, role, canPlan }: ReportingModuleProps) {
   const [chores, setChores] = useState<any[]>([]);
   const [completions, setCompletions] = useState<any[]>([]);
   const [assignments, setAssignments] = useState<any[]>([]);
@@ -53,7 +54,7 @@ export default function ReportingModule({ user, familyId, role }: ReportingModul
     }
   };
 
-  const canManage = useMemo(() => canEditContent(role), [role]);
+  const canManage = useMemo(() => canEditContent({ role, canPlan }), [role, canPlan]);
 
   const knownChildren = useMemo(
     () => deriveKnownChildren(completions, assignments),

--- a/src/utils/__tests__/dashboardModules.test.ts
+++ b/src/utils/__tests__/dashboardModules.test.ts
@@ -31,8 +31,8 @@ describe('MODULE_ROLE_REQUIREMENTS', () => {
     expect(MODULE_ROLE_REQUIREMENTS.admin).toEqual(['ADMIN']);
   });
 
-  it('restricts reporting module to ADMIN and PLANNER roles', () => {
-    expect(MODULE_ROLE_REQUIREMENTS.reporting).toEqual(['ADMIN', 'PLANNER']);
+  it('restricts reporting module to planning-enabled members and admins', () => {
+    expect(MODULE_ROLE_REQUIREMENTS.reporting).toBe('PLAN');
   });
 
   it('leaves general modules unrestricted (null)', () => {
@@ -49,38 +49,42 @@ describe('MODULE_ROLE_REQUIREMENTS', () => {
 
 describe('canAccessModule', () => {
   it('allows ADMIN to access all modules', () => {
+    const adminMembership = { role: 'ADMIN' as const, canPlan: true };
     for (const mod of DASHBOARD_MODULES) {
-      expect(canAccessModule(mod, 'ADMIN')).toBe(true);
+      expect(canAccessModule(mod, adminMembership)).toBe(true);
     }
   });
 
-  it('allows PLANNER to access reporting', () => {
-    expect(canAccessModule('reporting', 'PLANNER')).toBe(true);
+  it('allows planning-enabled MEMBER to access reporting', () => {
+    expect(canAccessModule('reporting', { role: 'MEMBER', canPlan: true })).toBe(true);
   });
 
-  it('denies PLANNER access to admin', () => {
-    expect(canAccessModule('admin', 'PLANNER')).toBe(false);
-  });
-
-  it('denies MEMBER access to reporting', () => {
-    expect(canAccessModule('reporting', 'MEMBER')).toBe(false);
+  it('denies planning-disabled MEMBER access to reporting', () => {
+    expect(canAccessModule('reporting', { role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('denies MEMBER access to admin', () => {
-    expect(canAccessModule('admin', 'MEMBER')).toBe(false);
+    expect(canAccessModule('admin', { role: 'MEMBER', canPlan: true })).toBe(false);
+    expect(canAccessModule('admin', { role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
-  it('allows MEMBER to access all open modules', () => {
+  it('allows MEMBER to access all open modules regardless of canPlan', () => {
     const openModules = ['vacations', 'planning', 'property', 'cars', 'calendar', 'cookbook', 'chores'] as const;
     for (const mod of openModules) {
-      expect(canAccessModule(mod, 'MEMBER')).toBe(true);
+      expect(canAccessModule(mod, { role: 'MEMBER', canPlan: false })).toBe(true);
+      expect(canAccessModule(mod, { role: 'MEMBER', canPlan: true })).toBe(true);
     }
   });
 
-  it('allows all roles to access the profile module', () => {
-    const roles = ['ADMIN', 'PLANNER', 'MEMBER'] as const;
-    for (const role of roles) {
-      expect(canAccessModule('profile', role)).toBe(true);
+  it('allows all memberships to access the profile module', () => {
+    const memberships = [
+      { role: 'ADMIN' as const, canPlan: true },
+      { role: 'MEMBER' as const, canPlan: false },
+      { role: 'MEMBER' as const, canPlan: true },
+    ];
+
+    for (const membership of memberships) {
+      expect(canAccessModule('profile', membership)).toBe(true);
     }
   });
 });

--- a/src/utils/__tests__/familyContext.test.ts
+++ b/src/utils/__tests__/familyContext.test.ts
@@ -167,7 +167,9 @@ describe('joinFamily', () => {
     });
 
     const membership = await joinFamily('VALID1', 'user-3');
-    expect(membership?.role).toBe('PLANNER');
+    // Stored PLANNER is normalized to MEMBER with canPlan: true
+    expect(membership?.role).toBe('MEMBER');
+    expect(membership?.canPlan).toBe(true);
     expect(mockFamilyMember.create).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/__tests__/inviteOnboarding.test.ts
+++ b/src/utils/__tests__/inviteOnboarding.test.ts
@@ -105,14 +105,16 @@ describe('redeemInviteToken – success cases', () => {
     expect(mockRedeemInvite).toHaveBeenCalledWith({ token: 'valid-token' });
   });
 
-  it('returns PLANNER role when the invite role is PLANNER', async () => {
+  it('returns planning-enabled MEMBER when the invite role is PLANNER', async () => {
     mockRedeemInvite.mockResolvedValue({
       data: { familyId: 'fam-2', familyName: 'The Joneses', role: 'PLANNER' },
       errors: null,
     });
 
     const membership = await redeemInviteToken('planner-token');
-    expect(membership.role).toBe('PLANNER');
+    // Stored PLANNER is normalized to MEMBER with canPlan: true
+    expect(membership.role).toBe('MEMBER');
+    expect(membership.canPlan).toBe(true);
     expect(membership.familyName).toBe('The Joneses');
   });
 });

--- a/src/utils/__tests__/rolePermissions.test.ts
+++ b/src/utils/__tests__/rolePermissions.test.ts
@@ -1,28 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { EDITOR_ROLES, ADMIN_ONLY_ROLES, canEditContent, canDeleteContent } from '../rolePermissions';
+import { ADMIN_ONLY_ROLES, canEditContent, canDeleteContent } from '../rolePermissions';
 import type { FamilyRole } from '../familyContext';
-
-describe('EDITOR_ROLES', () => {
-  it('includes ADMIN', () => {
-    expect(EDITOR_ROLES).toContain('ADMIN');
-  });
-
-  it('includes PLANNER', () => {
-    expect(EDITOR_ROLES).toContain('PLANNER');
-  });
-
-  it('does not include MEMBER', () => {
-    expect(EDITOR_ROLES).not.toContain('MEMBER');
-  });
-});
 
 describe('ADMIN_ONLY_ROLES', () => {
   it('includes ADMIN', () => {
     expect(ADMIN_ONLY_ROLES).toContain('ADMIN');
-  });
-
-  it('does not include PLANNER', () => {
-    expect(ADMIN_ONLY_ROLES).not.toContain('PLANNER');
   });
 
   it('does not include MEMBER', () => {
@@ -32,44 +14,40 @@ describe('ADMIN_ONLY_ROLES', () => {
 
 describe('canEditContent', () => {
   it('allows ADMIN to create/edit content', () => {
-    expect(canEditContent('ADMIN')).toBe(true);
+    expect(canEditContent({ role: 'ADMIN', canPlan: true })).toBe(true);
   });
 
-  it('allows PLANNER to create/edit content', () => {
-    expect(canEditContent('PLANNER')).toBe(true);
+  it('allows planning-enabled MEMBER to create/edit content', () => {
+    expect(canEditContent({ role: 'MEMBER', canPlan: true })).toBe(true);
   });
 
-  it('denies MEMBER from creating/editing content', () => {
-    expect(canEditContent('MEMBER')).toBe(false);
-  });
-
-  it('covers all FamilyRole values without ambiguity', () => {
-    const allRoles: FamilyRole[] = ['ADMIN', 'PLANNER', 'MEMBER'];
-    const editorCount = allRoles.filter(canEditContent).length;
-    const readOnlyCount = allRoles.filter((r) => !canEditContent(r)).length;
-    expect(editorCount).toBe(2);   // ADMIN + PLANNER
-    expect(readOnlyCount).toBe(1); // MEMBER
+  it('denies planning-disabled MEMBER from creating/editing content', () => {
+    expect(canEditContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 });
 
 describe('canDeleteContent', () => {
   it('allows ADMIN to delete records', () => {
-    expect(canDeleteContent('ADMIN')).toBe(true);
+    expect(canDeleteContent({ role: 'ADMIN', canPlan: true })).toBe(true);
   });
 
-  it('denies PLANNER from deleting records', () => {
-    expect(canDeleteContent('PLANNER')).toBe(false);
+  it('denies planning-enabled MEMBER from deleting records', () => {
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: true })).toBe(false);
   });
 
   it('denies MEMBER from deleting records', () => {
-    expect(canDeleteContent('MEMBER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('only ADMIN may delete – mirrors backend schema authorization', () => {
-    const allRoles: FamilyRole[] = ['ADMIN', 'PLANNER', 'MEMBER'];
-    const deleteCount = allRoles.filter(canDeleteContent).length;
-    const noDeleteCount = allRoles.filter((r) => !canDeleteContent(r)).length;
+    const memberships: Array<{ role: FamilyRole; canPlan: boolean }> = [
+      { role: 'ADMIN', canPlan: true },
+      { role: 'MEMBER', canPlan: true },
+      { role: 'MEMBER', canPlan: false },
+    ];
+    const deleteCount = memberships.filter(canDeleteContent).length;
+    const noDeleteCount = memberships.filter((m) => !canDeleteContent(m)).length;
     expect(deleteCount).toBe(1);   // ADMIN only
-    expect(noDeleteCount).toBe(2); // PLANNER + MEMBER
+    expect(noDeleteCount).toBe(2); // MEMBER (canPlan or not)
   });
 });

--- a/src/utils/__tests__/security.rbac.test.ts
+++ b/src/utils/__tests__/security.rbac.test.ts
@@ -29,9 +29,9 @@
 import { describe, it, expect } from 'vitest';
 import { canEditContent, canDeleteContent } from '../rolePermissions';
 import { validateRoleUpdate } from '../roleMutationGuards';
-import type { FamilyRole } from '../familyContext';
+import type { StoredMemberRole } from '../roleMutationGuards';
 
-const ALL_ROLES: FamilyRole[] = ['ADMIN', 'PLANNER', 'MEMBER'];
+const ALL_ROLES: StoredMemberRole[] = ['ADMIN', 'PLANNER', 'MEMBER'];
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Negative Testing – The "Blocker" Suite
@@ -41,89 +41,89 @@ const ALL_ROLES: FamilyRole[] = ['ADMIN', 'PLANNER', 'MEMBER'];
 
 describe('security.rbac – delete gate (MEMBER blocked)', () => {
   it('security.rbac.member-cannot-delete-vacation', () => {
-    expect(canDeleteContent('MEMBER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-delete-tripplan', () => {
-    expect(canDeleteContent('MEMBER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-delete-chore', () => {
-    expect(canDeleteContent('MEMBER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-delete-chore-assignment', () => {
-    expect(canDeleteContent('MEMBER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-delete-chore-completion', () => {
-    expect(canDeleteContent('MEMBER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-delete-car', () => {
-    expect(canDeleteContent('MEMBER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-delete-car-service', () => {
-    expect(canDeleteContent('MEMBER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-delete-recipe', () => {
-    expect(canDeleteContent('MEMBER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 });
 
-describe('security.rbac – delete gate (PLANNER blocked)', () => {
+describe('security.rbac – delete gate (planning-enabled MEMBER blocked)', () => {
   it('security.rbac.planner-cannot-delete-vacation', () => {
-    expect(canDeleteContent('PLANNER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: true })).toBe(false);
   });
 
   it('security.rbac.planner-cannot-delete-tripplan', () => {
-    expect(canDeleteContent('PLANNER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: true })).toBe(false);
   });
 
   it('security.rbac.planner-cannot-delete-chore', () => {
-    expect(canDeleteContent('PLANNER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: true })).toBe(false);
   });
 
   it('security.rbac.planner-cannot-delete-chore-assignment', () => {
-    expect(canDeleteContent('PLANNER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: true })).toBe(false);
   });
 
   it('security.rbac.planner-cannot-delete-car', () => {
-    expect(canDeleteContent('PLANNER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: true })).toBe(false);
   });
 
   it('security.rbac.planner-cannot-delete-recipe', () => {
-    expect(canDeleteContent('PLANNER')).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: true })).toBe(false);
   });
 });
 
-// ── Create / edit gate: MEMBER is read-only for protected models ───────────────
+// ── Create / edit gate: MEMBER without canPlan is read-only ───────────────────
 
 describe('security.rbac – create/edit gate (MEMBER blocked)', () => {
   it('security.rbac.member-cannot-create-vacation', () => {
-    expect(canEditContent('MEMBER')).toBe(false);
+    expect(canEditContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-create-tripplan', () => {
-    expect(canEditContent('MEMBER')).toBe(false);
+    expect(canEditContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-create-chore', () => {
-    expect(canEditContent('MEMBER')).toBe(false);
+    expect(canEditContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-create-chore-assignment', () => {
-    expect(canEditContent('MEMBER')).toBe(false);
+    expect(canEditContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-create-car', () => {
-    expect(canEditContent('MEMBER')).toBe(false);
+    expect(canEditContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-cannot-create-recipe', () => {
-    expect(canEditContent('MEMBER')).toBe(false);
+    expect(canEditContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 });
 
@@ -248,27 +248,31 @@ describe('security.rbac – tenant isolation (cross-family access blocked)', () 
 
 describe('security.rbac – delete gate exhaustiveness', () => {
   it('security.rbac.only-admin-passes-delete-gate', () => {
-    const canDelete = ALL_ROLES.filter(canDeleteContent);
-    expect(canDelete).toEqual(['ADMIN']);
+    const memberships = [
+      { role: 'ADMIN' as const, canPlan: true },
+      { role: 'MEMBER' as const, canPlan: true },
+      { role: 'MEMBER' as const, canPlan: false },
+    ];
+    const canDelete = memberships.filter(canDeleteContent);
+    expect(canDelete).toHaveLength(1);
+    expect(canDelete[0].role).toBe('ADMIN');
   });
 
   it('security.rbac.delete-gate-rejects-non-admin-roles', () => {
-    const blocked = ALL_ROLES.filter((r) => !canDeleteContent(r));
-    expect(blocked).toEqual(expect.arrayContaining(['PLANNER', 'MEMBER']));
-    expect(blocked).toHaveLength(2);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: true })).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 });
 
 describe('security.rbac – create/edit gate exhaustiveness', () => {
-  it('security.rbac.only-admin-and-planner-pass-edit-gate', () => {
-    const canEdit = ALL_ROLES.filter(canEditContent);
-    expect(canEdit).toEqual(expect.arrayContaining(['ADMIN', 'PLANNER']));
-    expect(canEdit).not.toContain('MEMBER');
-    expect(canEdit).toHaveLength(2);
+  it('security.rbac.only-admin-and-planners-pass-edit-gate', () => {
+    expect(canEditContent({ role: 'ADMIN', canPlan: true })).toBe(true);
+    expect(canEditContent({ role: 'MEMBER', canPlan: true })).toBe(true);
+    expect(canEditContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-fails-edit-gate', () => {
-    expect(canEditContent('MEMBER')).toBe(false);
+    expect(canEditContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 });
 
@@ -280,39 +284,39 @@ describe('security.rbac – create/edit gate exhaustiveness', () => {
 
 describe('security.rbac – ADMIN has full CRUD (positive)', () => {
   it('security.rbac.admin-can-delete-vacation', () => {
-    expect(canDeleteContent('ADMIN')).toBe(true);
+    expect(canDeleteContent({ role: 'ADMIN', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.admin-can-delete-tripplan', () => {
-    expect(canDeleteContent('ADMIN')).toBe(true);
+    expect(canDeleteContent({ role: 'ADMIN', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.admin-can-delete-chore', () => {
-    expect(canDeleteContent('ADMIN')).toBe(true);
+    expect(canDeleteContent({ role: 'ADMIN', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.admin-can-delete-chore-assignment', () => {
-    expect(canDeleteContent('ADMIN')).toBe(true);
+    expect(canDeleteContent({ role: 'ADMIN', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.admin-can-delete-car', () => {
-    expect(canDeleteContent('ADMIN')).toBe(true);
+    expect(canDeleteContent({ role: 'ADMIN', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.admin-can-delete-recipe', () => {
-    expect(canDeleteContent('ADMIN')).toBe(true);
+    expect(canDeleteContent({ role: 'ADMIN', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.admin-can-create-vacation', () => {
-    expect(canEditContent('ADMIN')).toBe(true);
+    expect(canEditContent({ role: 'ADMIN', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.admin-can-create-chore', () => {
-    expect(canEditContent('ADMIN')).toBe(true);
+    expect(canEditContent({ role: 'ADMIN', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.admin-can-create-car', () => {
-    expect(canEditContent('ADMIN')).toBe(true);
+    expect(canEditContent({ role: 'ADMIN', canPlan: true })).toBe(true);
   });
 });
 
@@ -387,39 +391,39 @@ describe('security.rbac – ADMIN role management (positive)', () => {
   });
 });
 
-// ── PLANNER: create and update permissions ────────────────────────────────────
+// ── Planning-enabled MEMBER: create and update permissions ────────────────────
 
-describe('security.rbac – PLANNER create/update permissions (positive)', () => {
+describe('security.rbac – planning-enabled MEMBER create/update permissions (positive)', () => {
   it('security.rbac.planner-can-create-vacation', () => {
-    expect(canEditContent('PLANNER')).toBe(true);
+    expect(canEditContent({ role: 'MEMBER', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.planner-can-update-vacation', () => {
-    expect(canEditContent('PLANNER')).toBe(true);
+    expect(canEditContent({ role: 'MEMBER', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.planner-can-create-tripplan', () => {
-    expect(canEditContent('PLANNER')).toBe(true);
+    expect(canEditContent({ role: 'MEMBER', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.planner-can-create-chore', () => {
-    expect(canEditContent('PLANNER')).toBe(true);
+    expect(canEditContent({ role: 'MEMBER', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.planner-can-update-chore', () => {
-    expect(canEditContent('PLANNER')).toBe(true);
+    expect(canEditContent({ role: 'MEMBER', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.planner-can-create-car', () => {
-    expect(canEditContent('PLANNER')).toBe(true);
+    expect(canEditContent({ role: 'MEMBER', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.planner-can-update-car', () => {
-    expect(canEditContent('PLANNER')).toBe(true);
+    expect(canEditContent({ role: 'MEMBER', canPlan: true })).toBe(true);
   });
 
   it('security.rbac.planner-can-create-recipe', () => {
-    expect(canEditContent('PLANNER')).toBe(true);
+    expect(canEditContent({ role: 'MEMBER', canPlan: true })).toBe(true);
   });
 });
 
@@ -427,10 +431,8 @@ describe('security.rbac – PLANNER create/update permissions (positive)', () =>
 
 describe('security.rbac – MEMBER read and chore completion (positive)', () => {
   it('security.rbac.member-read-is-permitted-canEditContent-is-false', () => {
-    // Read access for all groups is granted via allow.groups(['ADMIN','PLANNER','MEMBER']).to(['read']).
-    // canEditContent returning false means MEMBER cannot write, but read is still allowed.
-    expect(canEditContent('MEMBER')).toBe(false);
-    expect(canDeleteContent('MEMBER')).toBe(false);
+    expect(canEditContent({ role: 'MEMBER', canPlan: false })).toBe(false);
+    expect(canDeleteContent({ role: 'MEMBER', canPlan: false })).toBe(false);
   });
 
   it('security.rbac.member-can-log-chore-completion', () => {

--- a/src/utils/dashboardModules.ts
+++ b/src/utils/dashboardModules.ts
@@ -1,4 +1,4 @@
-import type { FamilyRole } from './familyContext';
+import type { FamilyMembership, FamilyRole } from './familyContext';
 
 export const DASHBOARD_MODULES = [
   'vacations',
@@ -18,8 +18,11 @@ export type ActiveModule = (typeof DASHBOARD_MODULES)[number];
 /**
  * Defines which roles may access each module.
  * `null` means the module is accessible by all authenticated family members.
+ * `PLAN` means users with planning capability (or ADMIN) may access.
  */
-export const MODULE_ROLE_REQUIREMENTS: Record<ActiveModule, FamilyRole[] | null> = {
+export type ModuleAccessRequirement = FamilyRole[] | 'PLAN' | null;
+
+export const MODULE_ROLE_REQUIREMENTS: Record<ActiveModule, ModuleAccessRequirement> = {
   vacations: null,
   planning: null,
   property: null,
@@ -27,16 +30,22 @@ export const MODULE_ROLE_REQUIREMENTS: Record<ActiveModule, FamilyRole[] | null>
   calendar: null,
   cookbook: null,
   chores: null,
-  reporting: ['ADMIN', 'PLANNER'],
+  reporting: 'PLAN',
   admin: ['ADMIN'],
   profile: null,
 };
 
 /**
- * Returns true if the given role is permitted to access the given module.
+ * Returns true if the given member permissions allow access to the module.
  */
-export function canAccessModule(module: ActiveModule, role: FamilyRole): boolean {
+export function canAccessModule(
+  module: ActiveModule,
+  membership: Pick<FamilyMembership, 'role' | 'canPlan'>
+): boolean {
   const required = MODULE_ROLE_REQUIREMENTS[module];
   if (required === null) return true;
-  return required.includes(role);
+  if (required === 'PLAN') {
+    return membership.role === 'ADMIN' || membership.canPlan;
+  }
+  return required.includes(membership.role);
 }

--- a/src/utils/familyContext.ts
+++ b/src/utils/familyContext.ts
@@ -11,11 +11,14 @@ import type { Schema } from '../../amplify/data/resource';
 
 const client = generateClient<Schema>();
 
-export type FamilyRole = 'ADMIN' | 'PLANNER' | 'MEMBER';
+type StoredMemberRole = 'ADMIN' | 'PLANNER' | 'MEMBER';
+
+export type FamilyRole = 'ADMIN' | 'MEMBER';
 
 export interface FamilyMembership {
   familyId: string;
   role: FamilyRole;
+  canPlan: boolean;
   displayName: string | null | undefined;
   familyName: string | null;
   familyJoinCode: string | null;
@@ -37,6 +40,21 @@ export function generateJoinCode(): string {
  * Look up the FamilyMember record for the given userId.
  * Returns null if the user has no family membership.
  */
+function normalizeMembershipRole(role: string | null | undefined): {
+  role: FamilyRole;
+  canPlan: boolean;
+} {
+  const storedRole = (role ?? 'MEMBER') as StoredMemberRole;
+  if (storedRole === 'ADMIN') {
+    return { role: 'ADMIN', canPlan: true };
+  }
+
+  return {
+    role: 'MEMBER',
+    canPlan: storedRole === 'PLANNER',
+  };
+}
+
 export async function getFamilyMembership(
   userId: string
 ): Promise<FamilyMembership | null> {
@@ -62,9 +80,12 @@ export async function getFamilyMembership(
       // Family lookup is best-effort
     }
 
+    const normalizedRole = normalizeMembershipRole(member.role ?? 'MEMBER');
+
     return {
       familyId: member.familyId,
-      role: (member.role ?? 'MEMBER') as FamilyRole,
+      role: normalizedRole.role,
+      canPlan: normalizedRole.canPlan,
       displayName: member.displayName,
       familyName,
       familyJoinCode,
@@ -126,6 +147,7 @@ export async function createFamily(
   return {
     familyId: family.id,
     role: 'ADMIN',
+    canPlan: true,
     displayName: member.displayName,
     familyName: family.name,
     familyJoinCode: family.joinCode ?? null,
@@ -159,9 +181,12 @@ export async function joinFamily(
   });
 
   if (existing && existing.length > 0) {
+    const normalizedRole = normalizeMembershipRole(existing[0].role ?? 'MEMBER');
+
     return {
       familyId: family.id,
-      role: (existing[0].role ?? 'MEMBER') as FamilyRole,
+      role: normalizedRole.role,
+      canPlan: normalizedRole.canPlan,
       displayName: existing[0].displayName,
       familyName: family.name,
       familyJoinCode: family.joinCode ?? null,
@@ -192,6 +217,7 @@ export async function joinFamily(
   return {
     familyId: family.id,
     role: 'MEMBER',
+    canPlan: false,
     displayName: member.displayName,
     familyName: family.name,
     familyJoinCode: family.joinCode ?? null,
@@ -218,9 +244,12 @@ export async function redeemInviteToken(token: string): Promise<FamilyMembership
     );
   }
 
+  const normalizedRole = normalizeMembershipRole(result.role as string);
+
   return {
     familyId: result.familyId,
-    role: result.role as FamilyRole,
+    role: normalizedRole.role,
+    canPlan: normalizedRole.canPlan,
     displayName: null,
     familyName: result.familyName,
     familyJoinCode: null,

--- a/src/utils/roleMutationGuards.ts
+++ b/src/utils/roleMutationGuards.ts
@@ -1,6 +1,13 @@
 import type { FamilyRole } from './familyContext';
 
 /**
+ * Stored role values in DynamoDB – includes the legacy PLANNER value for
+ * backward compatibility.  UI components use FamilyRole (ADMIN | MEMBER) with
+ * the canPlan flag; the backend still stores PLANNER for existing records.
+ */
+export type StoredMemberRole = FamilyRole | 'PLANNER';
+
+/**
  * Validates a role update request, enforcing:
  *   1. The new role must be a valid FamilyRole value.
  *   2. The caller must hold the ADMIN role (privilege-escalation protection).
@@ -15,11 +22,11 @@ import type { FamilyRole } from './familyContext';
  *          `null` when the update is permitted.
  */
 export function validateRoleUpdate(params: {
-  callerRole: FamilyRole;
+  callerRole: StoredMemberRole;
   callerFamilyId: string;
-  targetCurrentRole: FamilyRole;
+  targetCurrentRole: StoredMemberRole;
   targetFamilyId: string;
-  newRole: FamilyRole;
+  newRole: StoredMemberRole;
   adminCountInFamily: number;
 }): string | null {
   const {
@@ -31,7 +38,7 @@ export function validateRoleUpdate(params: {
     adminCountInFamily,
   } = params;
 
-  const VALID_ROLES: FamilyRole[] = ['ADMIN', 'PLANNER', 'MEMBER'];
+  const VALID_ROLES: StoredMemberRole[] = ['ADMIN', 'PLANNER', 'MEMBER'];
 
   if (!VALID_ROLES.includes(newRole)) {
     return `Invalid role: ${newRole}`;

--- a/src/utils/rolePermissions.ts
+++ b/src/utils/rolePermissions.ts
@@ -1,16 +1,6 @@
 import type { FamilyRole } from './familyContext';
 
 /**
- * Roles that may create, edit, and update content in modules where MEMBER
- * users have read-only access (e.g. TripPlan, Chore management).
- *
- * Role authority is managed through the FamilyMember model, not through
- * Cognito group membership.  Always use these constants instead of reading
- * Cognito group claims from the auth session.
- */
-export const EDITOR_ROLES: readonly FamilyRole[] = ['ADMIN', 'PLANNER'];
-
-/**
  * Roles that may permanently delete records.  Delete operations are
  * restricted to ADMIN at both the API and UI layers to prevent accidental
  * or malicious data loss by lower-privilege roles.
@@ -18,11 +8,11 @@ export const EDITOR_ROLES: readonly FamilyRole[] = ['ADMIN', 'PLANNER'];
 export const ADMIN_ONLY_ROLES: readonly FamilyRole[] = ['ADMIN'];
 
 /**
- * Returns true if the given FamilyMember role may create or update content.
- * MEMBER users are read-only in protected modules.
+ * Returns true if the given membership may create or update content.
+ * A member may edit content if they are an ADMIN or have the canPlan flag set.
  */
-export function canEditContent(role: FamilyRole): boolean {
-  return EDITOR_ROLES.includes(role);
+export function canEditContent(membership: { role: FamilyRole; canPlan: boolean }): boolean {
+  return membership.role === 'ADMIN' || membership.canPlan;
 }
 
 /**
@@ -30,6 +20,6 @@ export function canEditContent(role: FamilyRole): boolean {
  * Only ADMIN users are permitted to delete records; the same restriction
  * is enforced at the API level via the Amplify schema authorization rules.
  */
-export function canDeleteContent(role: FamilyRole): boolean {
-  return ADMIN_ONLY_ROLES.includes(role);
+export function canDeleteContent(membership: { role: FamilyRole; canPlan: boolean }): boolean {
+  return membership.role === 'ADMIN';
 }


### PR DESCRIPTION
- Introduced a new role system that normalizes 'PLANNER' to 'MEMBER' with planning capabilities.
- Updated AdminModule to handle new role structure and permissions for invites.
- Modified ChoresModule, PlanningModule, and ReportingModule to accept and utilize the new 'canPlan' property.
- Adjusted role permissions and access checks across modules to reflect the new role definitions.
- Updated tests to validate the new role and permission logic, ensuring proper access control.
- Refactored utility functions to accommodate the changes in role handling and permissions.