### PR TITLE
Postgres in Docker Migration: docker-compose, settings, backups, cutover runbook

### DIFF
--- a/deploy/backup-db-postgres.sh
+++ b/deploy/backup-db-postgres.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Nightly Postgres backup, run on the Lightsail instance via cron.
+# Supersedes deploy/backup-db.sh (SQLite) once the Postgres cutover is complete —
+# see docs/deploy/postgres-migration.md.
+set -euo pipefail
+
+APP_DIR=/srv/family-app
+BACKUP_DIR="$APP_DIR/backups"
+ENV_FILE=/etc/family-app/env
+RETENTION_DAYS=30
+
+mkdir -p "$BACKUP_DIR"
+
+set -a
+source <(sudo cat "$ENV_FILE")
+set +a
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+BACKUP_FILE="$BACKUP_DIR/pg-$TIMESTAMP.sql.gz"
+
+docker compose -f "$APP_DIR/deploy/docker-compose.yml" --env-file "$ENV_FILE" \
+    exec -T postgres pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_FILE"
+
+find "$BACKUP_DIR" -name "pg-*.sql.gz" -mtime "+$RETENTION_DAYS" -delete
+
+if [ -n "${BACKUP_S3_BUCKET:-}" ]; then
+    aws s3 cp "$BACKUP_FILE" "s3://$BACKUP_S3_BUCKET/family-app-db/"
+fi

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    # Bound to localhost only — gunicorn connects locally, never exposed publicly.
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -15,3 +15,10 @@ SENTRY_DSN=
 
 # Nightly DB backup sync — leave blank to skip the S3 upload (local backups still run)
 BACKUP_S3_BUCKET=
+
+# Postgres (Docker container on this same Lightsail instance — see deploy/docker-compose.yml)
+DB_NAME=family_app
+DB_USER=family_app
+DB_PASSWORD=change-me-to-a-long-random-string
+DB_HOST=127.0.0.1
+DB_PORT=5432

--- a/deploy/family-app-backup-postgres.cron
+++ b/deploy/family-app-backup-postgres.cron
@@ -1,0 +1,4 @@
+# Install to /etc/cron.d/family-app-backup, REPLACING the SQLite-era version,
+# once the Postgres cutover (docs/deploy/postgres-migration.md) is complete.
+# Nightly Postgres backup at 3am, synced to S3 if BACKUP_S3_BUCKET is set in /etc/family-app/env.
+0 3 * * * ec2-user /srv/family-app/deploy/backup-db-postgres.sh >> /var/log/family-app/backup.log 2>&1

--- a/docs/deploy/postgres-migration.md
+++ b/docs/deploy/postgres-migration.md
@@ -1,0 +1,136 @@
+# SQLite → Postgres Migration Runbook
+
+Covers the full cutover from SQLite to Postgres running in a Docker container on
+the existing Lightsail instance (GitHub milestone #35). Do these steps in order,
+directly on the production box, **before** deploying the branch that switches
+`prod.py` to the Postgres engine.
+
+---
+
+## 1. Install Docker
+
+```bash
+sudo dnf install -y docker
+sudo systemctl enable --now docker
+sudo usermod -aG docker ec2-user
+# Log out and back in (or start a new SSH session) for the group change to apply
+docker compose version
+```
+
+## 2. Set the Postgres credentials
+
+Add to `/etc/family-app/env` (see `deploy/env.example` for the full list of new vars):
+
+```
+DB_NAME=family_app
+DB_USER=family_app
+DB_PASSWORD=<generate a long random string>
+DB_HOST=127.0.0.1
+DB_PORT=5432
+```
+
+## 3. Start the Postgres container
+
+```bash
+cd /srv/family-app
+docker compose -f deploy/docker-compose.yml --env-file /etc/family-app/env up -d
+docker compose -f deploy/docker-compose.yml --env-file /etc/family-app/env ps
+```
+
+Confirm it shows healthy before continuing.
+
+## 4. Back up the current SQLite database
+
+Non-negotiable — this is the point of no return for the old database file.
+
+```bash
+sudo /srv/family-app/deploy/backup-db.sh
+ls -la /srv/family-app/backups
+```
+
+## 5. Export all data from SQLite (still running on the current, pre-Postgres deploy)
+
+```bash
+cd /srv/family-app
+set -a; source <(sudo cat /etc/family-app/env); set +a
+export DJANGO_SETTINGS_MODULE=family_project.settings.prod
+# NOTE: at this point prod.py must still point at SQLite — run this BEFORE
+# merging/deploying the branch that switches DATABASES to Postgres.
+venv/bin/python manage.py dumpdata \
+    --natural-foreign --natural-primary \
+    --exclude contenttypes --exclude auth.permission --exclude admin.logentry --exclude sessions \
+    --indent 2 \
+    > /srv/family-app/data_backup.json
+
+wc -l /srv/family-app/data_backup.json
+```
+
+Copy `data_backup.json` off the box too (e.g. to S3), same as the legix export — it's your only portable copy of every table's data.
+
+## 6. Merge and deploy the Postgres-switch branch
+
+Once the export above is confirmed, merge the PR that switches `prod.py`'s `DATABASES` to Postgres and adds `psycopg2-binary`. The next `deploy.yml` run installs the new dependency and restarts gunicorn — but the app **will not come up successfully yet**, because the Postgres database has no schema. That's expected; continue immediately with step 7.
+
+## 7. Run migrations against the empty Postgres database
+
+```bash
+cd /srv/family-app
+set -a; source <(sudo cat /etc/family-app/env); set +a
+export DJANGO_SETTINGS_MODULE=family_project.settings.prod
+venv/bin/python manage.py migrate --noinput
+```
+
+## 8. Load the data into Postgres
+
+```bash
+venv/bin/python manage.py loaddata /srv/family-app/data_backup.json
+```
+
+## 9. Verify row counts match
+
+For each app's key models, spot-check counts against the original SQLite backup (open a second shell pointed at the SQLite backup file if needed, or compare against the `dumpdata` output's object count per model):
+
+```bash
+venv/bin/python manage.py shell -c "
+from django.contrib.auth import get_user_model
+from vehicles.models import Vehicle
+from property.models import Property, MaintenanceProject
+from vacations.models import Vacation
+from cookbook.models import Recipe
+from shopping.models import ShoppingItem
+from tasks.models import FamilyTask
+from core.models import FamilyAccount, FamilyMembership
+User = get_user_model()
+for m in [User, Vehicle, Property, MaintenanceProject, Vacation, Recipe, ShoppingItem, FamilyTask, FamilyAccount, FamilyMembership]:
+    print(m.__name__, m.objects.count())
+"
+```
+
+## 10. Restart and smoke test
+
+```bash
+sudo systemctl restart family-app
+sudo systemctl status family-app
+```
+
+Log in via the browser and click through the dashboard, a vehicle, a maintenance item, and the calendar — confirm real data shows up.
+
+## 11. Switch backups over to Postgres
+
+```bash
+sudo chmod +x /srv/family-app/deploy/backup-db-postgres.sh
+sudo cp /srv/family-app/deploy/family-app-backup-postgres.cron /etc/cron.d/family-app-backup
+sudo /srv/family-app/deploy/backup-db-postgres.sh   # one manual run to confirm it works
+```
+
+The old SQLite cron entry is now replaced. Keep the SQLite `.sqlite3` file and the `data_backup.json` export on S3 for at least 90 days as a rollback safety net.
+
+---
+
+## Rollback
+
+**Before step 6 (Postgres switch not yet deployed):** nothing to roll back — SQLite is still live and untouched.
+
+**After step 6, before step 8 completes successfully:** revert the `prod.py` DB-engine commit and redeploy; SQLite is still on disk, untouched. The app comes back up exactly as it was.
+
+**After step 8 (data loaded into Postgres) — cutting back to SQLite:** revert the `prod.py` commit and redeploy. Since no writes have gone to Postgres-only data yet (this is a low-traffic personal app, not a live multi-user cutover), the untouched SQLite file remains authoritative. If real usage has occurred against Postgres by the time a rollback is needed, restore the SQLite file from the step-4 backup instead, accepting loss of anything written only to Postgres in between.

--- a/family_project/settings/prod.py
+++ b/family_project/settings/prod.py
@@ -26,11 +26,12 @@ ALLOWED_HOSTS = [
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db" / "db.sqlite3",
-        "OPTIONS": {
-            "timeout": 20,
-        },
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ["DB_NAME"],
+        "USER": os.environ["DB_USER"],
+        "PASSWORD": os.environ["DB_PASSWORD"],
+        "HOST": os.environ.get("DB_HOST", "127.0.0.1"),
+        "PORT": os.environ.get("DB_PORT", "5432"),
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ icalendar
 requests
 sentry-sdk[django]>=2.0.0
 django-ratelimit>=4.1.0
+psycopg2-binary>=2.9


### PR DESCRIPTION
## Summary
- `deploy/docker-compose.yml` — Postgres 16 container, bound to `127.0.0.1` only, persistent named volume
- `prod.py` — `DATABASES` now points at Postgres (`psycopg2-binary`), reading `DB_NAME`/`DB_USER`/`DB_PASSWORD`/`DB_HOST`/`DB_PORT` from env. `dev.py`/`ci.py` untouched — still SQLite for local dev and CI
- `deploy/backup-db-postgres.sh` + `deploy/family-app-backup-postgres.cron` — nightly `pg_dump` synced to S3, to replace the SQLite backup cron once cutover is done
- `docs/deploy/postgres-migration.md` — full runbook: install Docker → start the container → export via `dumpdata` (while still on SQLite) → deploy this branch → `migrate` → `loaddata` → verify row counts → switch backups over. Includes a rollback plan for each stage.

## ⚠️ Do not merge/deploy before:
1. Docker is installed and the Postgres container is running on the Lightsail box (`docs/deploy/postgres-migration.md` steps 1-3)
2. `/etc/family-app/env` has `DB_NAME`/`DB_USER`/`DB_PASSWORD` set (step 2)
3. A full SQLite backup **and** a `dumpdata` export have both been taken (steps 4-5)

`prod.py` no longer has any SQLite fallback — `os.environ["DB_NAME"]` etc. use bracket access with no default, so deploying this before the container/env exist will crash the app on startup with a `KeyError`, not gracefully degrade.

## Test plan
- [x] Full suite (63/63) passing — unaffected, since dev/ci settings are untouched
- [x] `prod.py` syntax-checked
- [ ] Server-side: follow `docs/deploy/postgres-migration.md` end-to-end, verify row counts match, verify the app loads real data post-cutover

Refs #302, #303, #304, #305, #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)