### PR TITLE
Integrate Stripe billing via dj-stripe

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class CoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "core"
+
+    def ready(self):
+        from . import stripe_handlers  # noqa: F401

--- a/core/djstripe_callbacks.py
+++ b/core/djstripe_callbacks.py
@@ -1,0 +1,8 @@
+def get_subscriber_for_request(request):
+    """dj-stripe's DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK.
+
+    The paying subscriber in this app is a FamilyAccount (set via
+    TenantMiddleware), not the logged-in User — dj-stripe's own default
+    callback returns request.user, which is the wrong model here.
+    """
+    return request.account

--- a/core/models.py
+++ b/core/models.py
@@ -16,6 +16,12 @@ class FamilyAccount(models.Model):
     def __str__(self):
         return self.name
 
+    @property
+    def email(self):
+        # dj-stripe's Customer.get_or_create() requires the subscriber model
+        # to have an email — the owner's is the natural choice here.
+        return self.owner.email
+
 
 class FamilyMembership(models.Model):
     ROLE_CHOICES = [("owner", "Owner"), ("member", "Member")]

--- a/core/stripe_handlers.py
+++ b/core/stripe_handlers.py
@@ -1,0 +1,62 @@
+import logging
+
+from django.core.mail import send_mail
+from djstripe.event_handlers import djstripe_receiver
+from djstripe.models import Customer
+
+logger = logging.getLogger(__name__)
+
+
+def _account_for_stripe_customer(stripe_customer_id):
+    if not stripe_customer_id:
+        return None
+    try:
+        customer = Customer.objects.get(id=stripe_customer_id)
+    except Customer.DoesNotExist:
+        logger.warning("Webhook referenced unknown Stripe customer %s", stripe_customer_id)
+        return None
+    return customer.subscriber
+
+
+@djstripe_receiver(["customer.subscription.created"])
+def handle_subscription_created(sender, event, **kwargs):
+    stripe_customer_id = event.data.get("object", {}).get("customer")
+    account = _account_for_stripe_customer(stripe_customer_id)
+    if account and not account.is_active:
+        account.is_active = True
+        account.save(update_fields=["is_active"])
+
+
+@djstripe_receiver(["customer.subscription.deleted"])
+def handle_subscription_deleted(sender, event, **kwargs):
+    stripe_customer_id = event.data.get("object", {}).get("customer")
+    account = _account_for_stripe_customer(stripe_customer_id)
+    if account and account.is_active:
+        account.is_active = False
+        account.save(update_fields=["is_active"])
+
+
+@djstripe_receiver(["invoice.payment_failed"])
+def handle_payment_failed(sender, event, **kwargs):
+    stripe_customer_id = event.data.get("object", {}).get("customer")
+    account = _account_for_stripe_customer(stripe_customer_id)
+    if not account or not account.email:
+        return
+
+    try:
+        send_mail(
+            subject="Action needed: your Famly App payment didn't go through",
+            message=(
+                f"Hi {account.owner.first_name or account.owner.username},\n\n"
+                "We weren't able to process your latest payment for Famly App. "
+                "Please update your payment method to avoid losing access to "
+                f"the {account.name} account.\n\n"
+                "— Famly App"
+            ),
+            from_email=None,
+            recipient_list=[account.email],
+        )
+    except Exception:
+        # Email delivery isn't configured yet (see ticket #311) — don't let a
+        # notification failure break webhook processing or trigger Stripe retries.
+        logger.exception("Failed to send payment-failed email for account %s", account.pk)

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -22,3 +22,12 @@ DB_USER=family_app
 DB_PASSWORD=change-me-to-a-long-random-string
 DB_HOST=127.0.0.1
 DB_PORT=5432
+
+# Stripe / dj-stripe — leave blank until a Stripe account exists; billing stays
+# inert (no crash) with these unset. Set STRIPE_LIVE_MODE=true only when ready
+# to take real payments.
+STRIPE_LIVE_MODE=false
+STRIPE_TEST_SECRET_KEY=
+STRIPE_LIVE_SECRET_KEY=
+STRIPE_TEST_PUBLIC_KEY=
+STRIPE_LIVE_PUBLIC_KEY=

--- a/family_project/settings/base.py
+++ b/family_project/settings/base.py
@@ -83,3 +83,6 @@ LOGOUT_REDIRECT_URL = "/accounts/login/"
 # (not just prod.py) so every environment's migrations agree on the FK target.
 DJSTRIPE_SUBSCRIBER_MODEL = "core.FamilyAccount"
 DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK = "core.djstripe_callbacks.get_subscriber_for_request"
+# Required since dj-stripe 2.4, no default. "id" (Stripe's own string ID) is
+# recommended for new installations — this is one, there's no prior data.
+DJSTRIPE_FOREIGN_KEY_TO_FIELD = "id"

--- a/family_project/settings/base.py
+++ b/family_project/settings/base.py
@@ -21,6 +21,7 @@ INSTALLED_APPS = [
     "cookbook",
     "shopping",
     "tasks",
+    "djstripe",
 ]
 
 MIDDLEWARE = [
@@ -77,3 +78,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 LOGIN_URL = "/accounts/login/"
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/accounts/login/"
+
+# dj-stripe: the paying subscriber is a FamilyAccount, not a User — set in base.py
+# (not just prod.py) so every environment's migrations agree on the FK target.
+DJSTRIPE_SUBSCRIBER_MODEL = "core.FamilyAccount"
+DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK = "core.djstripe_callbacks.get_subscriber_for_request"

--- a/family_project/settings/prod.py
+++ b/family_project/settings/prod.py
@@ -49,6 +49,15 @@ GOOGLE_CALENDAR_ID = os.environ.get("GOOGLE_CALENDAR_ID", "primary")
 
 OUTLOOK_ICAL_URL = os.environ.get("OUTLOOK_ICAL_URL", "")
 
+# Stripe / dj-stripe — blank until a real Stripe account exists; djstripe's own
+# settings shim defaults every one of these to "" / False, so the app runs fine
+# with billing simply inert until they're set.
+STRIPE_LIVE_MODE = os.environ.get("STRIPE_LIVE_MODE", "false").lower() == "true"
+STRIPE_TEST_SECRET_KEY = os.environ.get("STRIPE_TEST_SECRET_KEY", "")
+STRIPE_LIVE_SECRET_KEY = os.environ.get("STRIPE_LIVE_SECRET_KEY", "")
+STRIPE_TEST_PUBLIC_KEY = os.environ.get("STRIPE_TEST_PUBLIC_KEY", "")
+STRIPE_LIVE_PUBLIC_KEY = os.environ.get("STRIPE_LIVE_PUBLIC_KEY", "")
+
 SECURE_HSTS_SECONDS = 31536000
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_HSTS_PRELOAD = True

--- a/family_project/urls.py
+++ b/family_project/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     # Rate-limited login must come before the auth.urls include so it wins the match.
     path("accounts/login/", RateLimitedLoginView.as_view(), name="login"),
     path("accounts/", include("django.contrib.auth.urls")),
+    path("stripe/", include("djstripe.urls", namespace="djstripe")),
     path("", include("core.urls")),
     path("vehicles/", include("vehicles.urls", namespace="vehicles")),
     path("property/", include("property.urls", namespace="property")),

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests
 sentry-sdk[django]>=2.0.0
 django-ratelimit>=4.1.0
 psycopg2-binary>=2.9
+dj-stripe==2.10.0


### PR DESCRIPTION
## Summary
- Adds `dj-stripe`, pinned to **2.10.0** rather than latest (2.11.0) — the newer release requires `django>=5.2`, which would silently force an unplanned Django 5.1→5.2 upgrade as a side effect of adding a billing library. 2.10.0 only needs `django>=5.0`, so it installs against whatever 5.1.x is already deployed with no forced bump.
- `FamilyAccount` (not `User`) is the paying subscriber, matching `SAAS_TRANSITION.md`'s original design — wired via `DJSTRIPE_SUBSCRIBER_MODEL` + a custom `DJSTRIPE_SUBSCRIBER_MODEL_REQUEST_CALLBACK` (dj-stripe's default returns `request.user`, the wrong model here). Added `FamilyAccount.email` (proxies to `owner.email`) since dj-stripe's `Customer.get_or_create()` requires the subscriber model to have one.
- Webhook handlers in `core/stripe_handlers.py` (connected via `core/apps.py`'s `ready()`):
  - `customer.subscription.created` → `account.is_active = True`
  - `customer.subscription.deleted` → `account.is_active = False`
  - `invoice.payment_failed` → grace-period email, wrapped in try/except (email delivery isn't configured yet — #311 — a failed notification shouldn't break webhook processing or trigger Stripe retries)
- `STRIPE_LIVE_MODE`/`*_SECRET_KEY`/`*_PUBLIC_KEY` all default to blank/False via env vars — billing stays completely inert with no crash until a real Stripe account exists.

## No Stripe account exists yet
This ticket was explicitly scoped to ship with that understanding. Once an account exists:
1. Get API keys from the Stripe dashboard (test mode first), set `STRIPE_TEST_SECRET_KEY`/`STRIPE_TEST_PUBLIC_KEY` in `/etc/family-app/env`
2. Register a webhook endpoint — dj-stripe's `WebhookEndpoint` model registers itself with Stripe's API on creation and stores the signing secret locally (creatable via Django admin, since `djstripe` is a registered admin app). Confirm the exact steps against dj-stripe's webhook setup docs at that point rather than trusting this summary blindly — that part hasn't been verified against a live account.
3. Flip `STRIPE_LIVE_MODE=true` only when ready to take real payments.

## Testing caveat
**This dev machine's Python (3.9) can't even import dj-stripe** (needs 3.11+), so nothing here has been run locally — not even `manage.py check`. CI (Python 3.11 per `unit-tests.yml`) is the only real verification this PR has had so far. The riskiest untested part is whether `DJSTRIPE_SUBSCRIBER_MODEL` pointed at `core.FamilyAccount` migrates cleanly — dj-stripe documents this as a first-class supported feature, but it's worth watching the CI migration step specifically.

Refs #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)